### PR TITLE
07 add api keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ gem "sorcery"
 
 gem 'jsonapi-serializer'
 
+gem 'rack-cors'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.2)
     rack (2.2.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8)
@@ -207,6 +209,7 @@ DEPENDENCIES
   jsonapi-serializer
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.4)
   sorcery
   tzinfo-data

--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::AuthenticationsController < Api::V1::BaseController
-  skip_before_action :authenticate
+  skip_before_action :authenticate, only: [:create]
 
   def create
     @user = login(params[:email], params[:password])
@@ -11,5 +11,10 @@ class Api::V1::AuthenticationsController < Api::V1::BaseController
     api_key = @user.activate_api_key!
     response.headers['AccessToken'] = api_key.access_token
     render json: json_string
+  end
+
+  def destroy
+    current_user.api_keys.active.update_all(expires_at: Time.current)
+    head :ok
   end
 end

--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::AuthenticationsController < Api::V1::BaseController
-  # skip_before_action :authenticate
+  skip_before_action :authenticate
 
   def create
     @user = login(params[:email], params[:password])
@@ -8,6 +8,8 @@ class Api::V1::AuthenticationsController < Api::V1::BaseController
     raise ActiveRecord::RecordNotFound unless @user
 
     json_string = UserSerializer.new(@user).serializable_hash.to_json
+    api_key = @user.activate_api_key!
+    response.headers['AccessToken'] = api_key.access_token
     render json: json_string
   end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,5 +1,26 @@
 class Api::V1::BaseController < ApplicationController
   include Api::ExceptionHandler
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  before_action :authenticate
+
+  protected
+
+  def authenticate
+    authenticate_or_request_with_http_token do |token, _options|
+      @_current_user ||= ApiKey.active.find_by(access_token: token)&.user
+    end
+  end
+
+  def current_user
+    @_current_user
+  end
+
+  def set_access_token!(user)
+    api_key = user.activate_api_key!
+    response.headers['AccessToken'] = api_key.access_token
+  end
+
 
   private
 

--- a/app/controllers/api/v1/questions_controller.rb
+++ b/app/controllers/api/v1/questions_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::QuestionsController < Api::V1::BaseController
+  skip_before_action :authenticate
+
   def filter
     subject_ids = params[:subject_ids]
     questions = Question.includes(:choices, :subject, :label).where(subject_id: subject_ids).order(:id)

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::RegistrationsController < Api::V1::BaseController
-  skip_before_action :authenticate
+  skip_before_action :authenticate, only: [:create]
+  before_action :set_user, only: [:destroy]
 
   def create
     @user = ::User.new(user_params)
@@ -16,9 +17,21 @@ class Api::V1::RegistrationsController < Api::V1::BaseController
     end
   end
 
+  def destroy
+    if @user.destroy
+      render json: { message: 'User successfully deleted.' }, status: :ok
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_params
     params.require(:user).permit(:name, :email, :password)
+  end
+
+  def set_user
+    @user = current_user
   end
 end

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class Api::V1::RegistrationsController < Api::V1::BaseController
-  # skip_before_action :authenticate
+  skip_before_action :authenticate
 
   def create
     @user = ::User.new(user_params)
 
     if @user.save
       json_string = UserSerializer.new(@user).serializable_hash.to_json
+      api_key = @user.activate_api_key!
+      response.headers['AccessToken'] = api_key.access_token
       render json: json_string
     else
       render_400(nil, @user.errors.full_messages)

--- a/app/controllers/api/v1/subjects_controller.rb
+++ b/app/controllers/api/v1/subjects_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::SubjectsController < Api::V1::BaseController
+  skip_before_action :authenticate
+
   def index
     subjects = Subject.all
     json_string = SubjectSerializer.new(subjects).serializable_hash.to_json

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,15 @@
+class ApiKey < ApplicationRecord
+  DEFAULT_EXPIRES_WEEK = 1.week
+  belongs_to :user
+
+  validates :access_token, uniqueness: true
+
+
+  scope :active, -> { where('expires_at >= ?', Time.current) }
+
+  def initialize(attributes = {})
+    super
+    self.access_token = SecureRandom.uuid
+    self.expires_at = DEFAULT_EXPIRES_WEEK.after
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,16 @@ class User < ApplicationRecord
 
   has_many :flags
   has_many :flagged_questions, through: :flags, source: :question
-
   has_many :user_question_relations
   has_many :answered_quesions, through: :user_question_relations, source: :question
+  has_many :api_keys
+
+  validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+
+  def activate_api_key! # 追記
+    return api_keys.active.first if api_keys.active.exists?
+
+    api_keys.create
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_many :flagged_questions, through: :flags, source: :question
   has_many :user_question_relations
   has_many :answered_quesions, through: :user_question_relations, source: :question
-  has_many :api_keys
+  has_many :api_keys, dependent: :destroy
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,13 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :subjects, only: [:index]
       resource :authentication, only: %i[create]
-      resource :registration, only: %i[create]
+      resources :registrations, only: [:create, :destroy]
       resources :questions, only: [:index] do
         collection do
           get 'filter'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :subjects, only: [:index]
-      resource :authentication, only: %i[create]
+      resource :authentication, only: [:create, :destroy]
       resources :registrations, only: [:create, :destroy]
       resources :questions, only: [:index] do
         collection do

--- a/db/migrate/20231119080820_create_api_keys.rb
+++ b/db/migrate/20231119080820_create_api_keys.rb
@@ -1,0 +1,13 @@
+class CreateApiKeys < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_keys do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :access_token
+      t.datetime :expires_at
+
+      t.timestamps
+
+      t.index ["access_token"], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_04_052214) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_19_080820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "api_keys", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "access_token"
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["access_token"], name: "index_api_keys_on_access_token", unique: true
+    t.index ["user_id"], name: "index_api_keys_on_user_id"
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name", null: false
@@ -104,6 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_04_052214) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "api_keys", "users"
   add_foreign_key "choices", "questions"
   add_foreign_key "flags", "questions"
   add_foreign_key "flags", "users"

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  access_token: MyString
+  expires_at: 2023-11-19 17:08:20
+
+two:
+  user: two
+  access_token: MyString
+  expires_at: 2023-11-19 17:08:20

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ApiKeyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
http://localhost:3000/api/v1/authentication にemailとpasswordをBodyにいれてPOSTすれば、レスポンスヘッダにアクセストークン（1週間有効）が返ってくる。
取得したアクセストークンを次以降のリクエストで、AuthorizationのBearer Tokenに記入すると、認証されていないと見れないレスポンスも見れる。
認証済みの状態で、http://localhost:3000/api/v1/authentication にDELETEリクエストを送れば、アクセストークンの期限が現在時刻に再設定され、ログアウトできる。

[![Image from Gyazo](https://i.gyazo.com/047f077a8917f1c44e909551ea8b3ea2.png)](https://gyazo.com/047f077a8917f1c44e909551ea8b3ea2)

http://localhost:3000/api/v1/registrations にname、email、passwordをBodyに入れてPOSTすれば、新規ユーザー登録ができる。レスポンスヘッダにアクセストークン（1週間有効）が返ってきて、ログイン状態になる。
ただし、`params.require(:user).permit(:name, :email, :password)`を使用しているため、下記のような構造のリクエストBodyにしないと弾かれるので注意。
```
{
  "user": {
    "email": "****@example.com",
    "password": "*****",
    "name": "example"
  }
}
```

認証済みの状態で、http://localhost:3000/api/v1/registrations/:id にDELETEリクエストを送れば、ユーザー情報とそれに紐づくアクセストークンテーブルレコードが削除される。